### PR TITLE
Error in a variable while building styles

### DIFF
--- a/src/table.scss
+++ b/src/table.scss
@@ -253,7 +253,7 @@
     @include share-rule(border-pseudo) {
       content: '';
       position: absolute;
-      background-color: $--table-border-color;
+      background-color: $--table-border;
       z-index: 1;
     }
 


### PR DESCRIPTION
Small bug when generating the theme chalk build, a variable that does not exist was being used.

```bash
Error: node_modules/element-theme-chalk/src/table.scss
Error: Undefined variable: "$--table-border-color".
        on line 256 of node_modules/element-theme-chalk/src/table.scss, in mixin `@content`
        from line 181 of node_modules/element-theme-chalk/src/mixins/mixins.scss, in mixin `share-rule`
        from line 253 of node_modules/element-theme-chalk/src/table.scss, in mixin `@content`
        from line 112 of node_modules/element-theme-chalk/src/mixins/mixins.scss, in mixin `m`
        from line 250 of node_modules/element-theme-chalk/src/table.scss, in mixin `@content`
        from line 74 of node_modules/element-theme-chalk/src/mixins/mixins.scss, in mixin `b`
        from line 7 of node_modules/element-theme-chalk/src/table.scss
        from line 24 of node_modules/element-theme-chalk/src/index.scss
>>       background-color: $--table-border-color;
```

I just renamed ``$--table-border-color`` to ``$--table-border``