### PR TITLE
Fix transfer component hiding items under footer

### DIFF
--- a/src/transfer.scss
+++ b/src/transfer.scss
@@ -74,7 +74,7 @@
     height: $--transfer-panel-body-height;
 
     @include when(with-footer) {
-      padding-bottom: $--transfer-panel-footer-height;
+      margin-bottom: $--transfer-panel-footer-height;
     }
   }
 


### PR DESCRIPTION
When there are too many items in the transfer panel the last two items (and scrollbar) get hidden under the panel footer because of this mistake.

Tested in Firefox and Chrome