### PR TITLE
fix: add missing background-color when focus on input component

### DIFF
--- a/src/input.scss
+++ b/src/input.scss
@@ -135,6 +135,7 @@
     &:focus {
       outline: none;
       border-color: $--input-focus-border;
+      background-color: $--input-focus-fill;
     }
   }
 


### PR DESCRIPTION
I tried to customize my theme, I found that when I changed the value of '$--input-focus-fill' in var.scss, but it didn't work.
I focused on the input component, the background color didn't change.
I found that though it defined the variable  '$--input-focus-fill', but the variable never be used.
So I added the property background-color at the .el-input__inner:focus in the input.scss and set the value to $--input-focus-fill.
Yes it works now!

Please check my commit and test it may be possible.
And thanks for your great jobs for us, wish you all the best and happy Chinese new year :)